### PR TITLE
feat: opts for resession dir and snacks finder function

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ local function generate_sessions()
     for idx, session in ipairs(require("resession").list({ dir = "gitsession" })) do
         local formatted = session:gsub("__", ":/"):gsub("_", "/")
 
-        if formatted:match("^" .. cwd) then
+        if formatted:find(cwd, 1, true) == 1 then
             sessions[#sessions + 1] = {
                 score = 0,
                 text = session,

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ With Snacks Picker:
 require("pick-resession").pick()
 ```
 
+
 **Key Maps:**
 
 | Picker | Mode           | Key Mapping | Description                 |
@@ -120,4 +121,36 @@ require("pick-resession").setup({
         { match = "/home/username", icon = "🏠", highlight = "Directory" },
     },
 })
+```
+
+### Example Snacks Picker Session Filtering
+
+```lua
+local function generate_sessions()
+    local cwd = vim.fn.getcwd()
+    local sessions = {}
+    for idx, session in ipairs(require("resession").list({ dir = "gitsession" })) do
+        local formatted = session:gsub("__", ":/"):gsub("_", "/")
+
+        if formatted:match("^" .. cwd) then
+            sessions[#sessions + 1] = {
+                score = 0,
+                text = session,
+                value = session,
+                idx = idx,
+                display_value = formatted,
+                file = formatted,
+            }
+        end
+    end
+    return sessions
+end
+
+-- Running `.pick()` will only return sesssions stored in the `gitsession`
+-- directory and that originate from the current working directory.
+require("pick-resession").pick({
+    snacks_finder = generate_sessions,
+    dir = "gitsession",
+})
+
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ With Snacks Picker:
 require("pick-resession").pick()
 ```
 
-
 **Key Maps:**
 
 | Picker | Mode           | Key Mapping | Description                 |
@@ -146,7 +145,7 @@ local function generate_sessions()
     return sessions
 end
 
--- Running `.pick()` will only return sesssions stored in the `gitsession`
+-- Running `.pick()` will only return sessions stored in the `gitsession`
 -- directory and that originate from the current working directory.
 require("pick-resession").pick({
     snacks_finder = generate_sessions,

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,6 @@
+telescope-resession-links	telescope-resession.txt	/*telescope-resession-links*
+telescope-resession-pick-resession.nvim	telescope-resession.txt	/*telescope-resession-pick-resession.nvim*
+telescope-resession-pick-resession.nvim-customization	telescope-resession.txt	/*telescope-resession-pick-resession.nvim-customization*
+telescope-resession-pick-resession.nvim-usage	telescope-resession.txt	/*telescope-resession-pick-resession.nvim-usage*
+telescope-resession-table-of-contents	telescope-resession.txt	/*telescope-resession-table-of-contents*
+telescope-resession.txt	telescope-resession.txt	/*telescope-resession.txt*

--- a/doc/tags
+++ b/doc/tags
@@ -1,6 +1,0 @@
-telescope-resession-links	telescope-resession.txt	/*telescope-resession-links*
-telescope-resession-pick-resession.nvim	telescope-resession.txt	/*telescope-resession-pick-resession.nvim*
-telescope-resession-pick-resession.nvim-customization	telescope-resession.txt	/*telescope-resession-pick-resession.nvim-customization*
-telescope-resession-pick-resession.nvim-usage	telescope-resession.txt	/*telescope-resession-pick-resession.nvim-usage*
-telescope-resession-table-of-contents	telescope-resession.txt	/*telescope-resession-table-of-contents*
-telescope-resession.txt	telescope-resession.txt	/*telescope-resession.txt*

--- a/lua/pick-resession/init.lua
+++ b/lua/pick-resession/init.lua
@@ -56,25 +56,23 @@ end
 
 M.pick = function(opts)
     opts = opts or {}
-    local snacks_finder = opts.snacks_finder or generate_sessions
-    local dir = opts.dir
     require("snacks").picker.pick({
         title = M.config.prompt_title,
-        finder = snacks_finder,
+        finder = opts.snacks_finder or generate_sessions(opts.dir),
         layout = M.config.layout,
         format = format_session_item,
         confirm = function(self, item)
             self:close()
             if opts.dir then
-                require("resession").load(item.value, { dir = dir })
+                require("resession").load(item.value, { dir = opts.dir })
             else
                 require("resession").load(item.value)
             end
         end,
         actions = {
             delete_session = function(self, item)
-                if dir then
-                    require("resession").delete(item.value, { dir = dir, notify = false })
+                if opts.dir ~= nil then
+                    require("resession").delete(item.value, { dir = opts.dir, notify = false })
                 else
                     require("resession").delete(item.value, { notify = false })
                 end

--- a/lua/pick-resession/init.lua
+++ b/lua/pick-resession/init.lua
@@ -30,13 +30,8 @@ local function format_session_item(item)
 end
 
 local function generate_sessions(dir)
-    local rawsessions = nil
-    if dir ~= nil then
-        rawsessions = require("resession").list({ dir = dir })
-    else
-        rawsessions = require("resession").list()
-    end
     return function()
+        local rawsessions = (dir ~= nil) and require("resession").list({ dir = dir }) or require("resession").list()
         local sessions = {}
         for idx, session in ipairs(rawsessions) do
             local formatted = session:gsub("__", ":/"):gsub("_", "/")


### PR DESCRIPTION
Allow users to set a `dir` and a `snacks_finder` option to customize the behavior when picking sessions using snacks.

This was done to be able to filter only for sessions from the current working directory.

This is my config for example:

```lua
return {
	"pyrho/pick-resession.nvim",
	dev = true,
	event = "VeryLazy",
	branch = "feat/custom-session-finder",
	dependencies = {
		"stevearc/resession.nvim",
		"folke/snacks.nvim", -- Ensure snacks.nvim is available
	},
	config = function()
		require("pick-resession").setup({ layout = "select" })

		local function generate_sessions()
			local cwd = vim.fn.getcwd()
			local sessions = {}
			for idx, session in ipairs(require("resession").list({ dir = "gitsession" })) do
				local formatted = session:gsub("__", ":/"):gsub("_", "/")

				if formatted:match("^" .. cwd) then
					sessions[#sessions + 1] = {
						score = 0,
						text = session,
						value = session,
						idx = idx,
						display_value = formatted,
						file = formatted,
					}
				end
			end
			return sessions
		end

		vim.keymap.set("n", "<leader>L", function()
			require("pick-resession").pick({
				snacks_finder = generate_sessions,
				dir = "gitsession",
			})
		end, { desc = "List sessions for current directory" })
	end,
}
```